### PR TITLE
Vincentmarchetti patch 1

### DIFF
--- a/VIEWER_JSON_DEMOS.md
+++ b/VIEWER_JSON_DEMOS.md
@@ -132,11 +132,12 @@ JSON
 
 ### X3D
 
-Currently, this demo loads one of the annotations described in [#17](https://github.com/IIIF/3d/issues/17) programattically, without an external JSON file.
+This demo loads one of the annotations described in [#17](https://github.com/IIIF/3d/issues/17).
 
-[Link to the demo](https://codesandbox.io/s/interesting-colden-ectroz)
+[Link to the demo](https://codesandbox.io/p/github/vincentmarchetti/x3d-remote-annotation/main)
 
 
 ## Changelog
 
 - 1/23/2023: Created this document to better record and track content evolving in [Issue #17](https://github.com/IIIF/3d/issues/17).
+- 3/21/2023: Update status and link of the X3D demo

--- a/VIEWER_JSON_DEMOS.md
+++ b/VIEWER_JSON_DEMOS.md
@@ -132,7 +132,7 @@ JSON
 
 ### X3D
 
-This demo loads one of the annotations described in [#17](https://github.com/IIIF/3d/issues/17).
+This demo loads annotation JSON object described in [#17](https://github.com/IIIF/3d/issues/17#issuecomment-1370034033) , with the modification that the position and normal coordinate are given as JSON array of numeric value rather than a string. A revised implementation of this demo could accommodate either form of the coordinate data.
 
 [Link to the demo](https://codesandbox.io/p/github/vincentmarchetti/x3d-remote-annotation/main)
 


### PR DESCRIPTION
I have changed the link provided for the X3D demo of the interoperable annotations; and clarified more precisely the JSON source of annotation specs used for the X3D demo