### PR TITLE
define backgroundColor in Scene

### DIFF
--- a/manifests/1_basic_model_in_scene/model_origin_bgcolor.json
+++ b/manifests/1_basic_model_in_scene/model_origin_bgcolor.json
@@ -3,13 +3,13 @@
   "id": "https://example.org/iiif/3d/model_origin.json",
   "type": "Manifest",
   "label": { "en": ["Single Model with background color"] },
-  "summary": { "en": ["Viewer should render the model at the origin, with a background color of purple, and then viewer should add default lighting and camera"] },
-  "backgroundColor": "#FF00FF",
+  "summary": { "en": ["Viewer should render the model at the origin, with a background color of purple, and then viewer should add default lighting and camera"] },  
   "items": [
     {
       "id": "https://example.org/iiif/scene1/page/p1/1",
       "type": "Scene",
       "label": { "en": ["A Scene"] },
+      "backgroundColor": "#FF00FE",
       "items": [
         {
           "id": "https://example.org/iiif/scene1/page/p1/1",


### PR DESCRIPTION
A backgroundColor property was incorrectly defined as a property of the Manifest. It has been moved into the Scene object.  The RGB values have been changed to 255,0,254 so that a unit test can verify the values of RGB are not being interchanged.