### PR TITLE
Update model_transform_negative_scale_position.json

### DIFF
--- a/manifests/4_transform_and_position/model_transform_negative_scale_position.json
+++ b/manifests/4_transform_and_position/model_transform_negative_scale_position.json
@@ -19,7 +19,7 @@
               "type": "Annotation",
               "motivation": ["painting"],
               "body": {
-                "id": "https://github.com/IIIF/3d/raw/main/assets/venus/venus.glb",
+                "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
                 "type": "Model"
               },
               "target": {
@@ -48,7 +48,7 @@
                 "type": "SpecificResource",
                 "source": [
                   {
-                    "id": "https://github.com/IIIF/3d/raw/main/assets/venus/venus.glb",
+                    "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
                     "type": "Model",
                     "format": "application/glb"
                   }


### PR DESCRIPTION
replaced the URL for the Model resource, in the body of both annotations, to https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb . It had previously been the venus.glb model and inaccessible (at least to x3dom) due to CORS policy on github server.