### PR TITLE
Typo in Manifest

### DIFF
--- a/manifests/4_transform_and_position/model_transform_translate_scale_position.json
+++ b/manifests/4_transform_and_position/model_transform_translate_scale_position.json
@@ -53,7 +53,7 @@
                     "format": "application/glb"
                   }
                 ],
-                "transforms": [
+                "transform": [
                   {
                     "type": "ScaleTransform",
                     "x": 2.0,

--- a/manifests/4_transform_and_position/model_transform_translate_scale_position.json
+++ b/manifests/4_transform_and_position/model_transform_translate_scale_position.json
@@ -53,7 +53,7 @@
                     "format": "application/glb"
                   }
                 ],
-                "transform" [
+                "transforms": [
                   {
                     "type": "ScaleTransform",
                     "x": 2.0,


### PR DESCRIPTION
Here is a small fix for a typo in a manifest. It wasn't possible to parse this file.