### PR TITLE
Specify a color and intensity for the directional light

### DIFF
--- a/manifests/3_lights/direction_light_transform_rotate.json
+++ b/manifests/3_lights/direction_light_transform_rotate.json
@@ -35,7 +35,9 @@
                   {
                     "id": "https://example.org/iiif/3d/lights/1",
                     "type": "DirectionalLight",
-                    "label": {"en": ["Directional Light 1"]}
+                    "label": {"en": ["Directional Light 1"]},
+                    "color": "#00FF00",
+                    "intensity": {"type": "Value", "value": 0.5, "unit": "relative"}
                   }
                 ],
                 "transform": [


### PR DESCRIPTION
The 3d:main 3_lights/direction_light_transform_rotate.json manifest did not have a color or intensity specified for the light. Since default values are not given in the draft api, a color and intensity are added to the manifest in this PR

color and intensity match the color and intensity of the draft ambient light, to allow comparison of the two lighting effects