### PR TITLE
Match id filename to actual filename

### DIFF
--- a/manifests/4_transform_and_position/model_transform_negative_scale_position.json
+++ b/manifests/4_transform_and_position/model_transform_negative_scale_position.json
@@ -1,6 +1,6 @@
 {
   "@context": "http://iiif.io/api/presentation/4/context.json",
-  "id": "https://example.org/iiif/3d/model_transform_scale.json",
+  "id": "https://example.org/iiif/3d/model_transform_negative_scale_position.json",
   "type": "Manifest",
   "label": { "en": ["Model shown normally and mirrored"] },
   "summary": { "en": ["Viewer should render the model twice, once at normal scale and once at normal scale but mirrored. Then the viewer should add default lighting and camera"] },

--- a/manifests/4_transform_and_position/model_transform_rotate_position.json
+++ b/manifests/4_transform_and_position/model_transform_rotate_position.json
@@ -1,6 +1,6 @@
 {
   "@context": "http://iiif.io/api/presentation/4/context.json",
-  "id": "https://example.org/iiif/3d/model_transform_scale.json",
+  "id": "https://example.org/iiif/3d/model_transform_rotate_position.json",
   "type": "Manifest",
   "label": { "en": ["Rotated Model"] },
   "summary": { "en": ["Viewer should render the model rotated by 180 degrees around the Y axis"] },

--- a/manifests/4_transform_and_position/model_transform_rotate_translate_position.json
+++ b/manifests/4_transform_and_position/model_transform_rotate_translate_position.json
@@ -1,6 +1,6 @@
 {
   "@context": "http://iiif.io/api/presentation/4/context.json",
-  "id": "https://example.org/iiif/3d/model_transform_scale.json",
+  "id": "https://example.org/iiif/3d/model_transform_rotate_translate_position.json",
   "type": "Manifest",
   "label": { "en": ["Rotated Translated Model"] },
   "summary": { "en": ["Viewer should render the model after rotating by 180 degrees around the Y axis, then translating 1 in X, resulting in him being at 1 in X"] },

--- a/manifests/4_transform_and_position/model_transform_scale_position.json
+++ b/manifests/4_transform_and_position/model_transform_scale_position.json
@@ -1,6 +1,6 @@
 {
   "@context": "http://iiif.io/api/presentation/4/context.json",
-  "id": "https://example.org/iiif/3d/model_transform_scale.json",
+  "id": "https://example.org/iiif/3d/model_transform_scale_position.json",
   "type": "Manifest",
   "label": { "en": ["Scaled, Translated Model with original for comparison"] },
   "summary": { "en": ["Viewer should render the model twice, once at normal scale and once at double scale after moving in the local coordinate space, and then the viewer should add default lighting and camera. Thus the model will end up at (5,4,4) due to doubling the scale of the local coordinate space."] },

--- a/manifests/4_transform_and_position/model_transform_scale_translate_position.json
+++ b/manifests/4_transform_and_position/model_transform_scale_translate_position.json
@@ -1,6 +1,6 @@
 {
   "@context": "http://iiif.io/api/presentation/4/context.json",
-  "id": "https://example.org/iiif/3d/model_transform_scale.json",
+  "id": "https://example.org/iiif/3d/model_transform_scale_translate_position.json",
   "type": "Manifest",
   "label": { "en": ["Scaled, Translated Model with original for comparison"] },
   "summary": { "en": ["Viewer should render the model twice, once at normal scale and once at double scale after moving in the local coordinate space, and then the viewer should add default lighting and camera. Thus the model will end up at (3,2,2) due to doubling the scale of the local coordinate space."] },

--- a/manifests/4_transform_and_position/model_transform_translate_rotate_position.json
+++ b/manifests/4_transform_and_position/model_transform_translate_rotate_position.json
@@ -1,6 +1,6 @@
 {
   "@context": "http://iiif.io/api/presentation/4/context.json",
-  "id": "https://example.org/iiif/3d/model_transform_scale.json",
+  "id": "https://example.org/iiif/3d/model_transform_translate_rotate_position.json",
   "type": "Manifest",
   "label": { "en": ["Translated Rotated Model"] },
   "summary": { "en": ["Viewer should render the model after moving 1 in X, then rotating by 180 degrees around the Y axis, resulting in him being at -1 in X"] },

--- a/manifests/4_transform_and_position/model_transform_translate_scale_position.json
+++ b/manifests/4_transform_and_position/model_transform_translate_scale_position.json
@@ -1,6 +1,6 @@
 {
   "@context": "http://iiif.io/api/presentation/4/context.json",
-  "id": "https://example.org/iiif/3d/model_transform_scale.json",
+  "id": "https://example.org/iiif/3d/model_transform_translate_scale_position.json",
   "type": "Manifest",
   "label": { "en": ["Scaled Model with original for comparison"] },
   "summary": { "en": ["Viewer should render the model twice, once at normal scale and once at double scale, and then the viewer should add default lighting and camera"] },


### PR DESCRIPTION
The `id`s in the section 4 example manifests don't match the filenames and are not unique.   This PR changes the filename in the `id` to match the actual filename.   It *does not* change the rest of the identifier, they still point to `https://example.org/...` 