### PR TITLE
Move scope on Content State whale example

### DIFF
--- a/manifests/xx_whale_comments/g_content_states.json
+++ b/manifests/xx_whale_comments/g_content_states.json
@@ -71,156 +71,162 @@
       ]
     }
   ],
-  "scope": [
+  "annotations": [
     {
-      "@context": "http://iiif.io/api/presentation/4/context.json",
-      "id": "https://example.org/iiif/3d/anno3",
-      "type": "Annotation",
-      "motivation": ["contentState"],
-      "target": {
-        "id": "https://example.org/iiif/scene1/page/p1/1",
-        "type": "Scene",
-        "backgroundColor": "green",
-        "items": [
-          {
-            "id": "https://example.org/iiif/3d/anno5",
-            "type": "Annotation",
-            "motivation": ["commenting"],
-            "bodyValue": "Right pterygoid hamulus",
-            "target": {
-              "type": "SpecificResource",
-              "source": [
-                {
-                  "id": "https://example.org/iiif/scene1",
-                  "type": "Scene"
-                }
-              ],
-              "selector": [
-                {
-                  "type": "PointSelector",
-                  "x": 0.040,
-                  "y": 0.063,
-                  "z": -0.066
-                }
-              ]
-            }
-          },
-          {
-            "id": "https://example.org/iiif/3d/anno6",
-            "type": "Annotation",
-            "motivation": ["painting"],
-            "body": {
-              "type": "SpecificResource",
-              "source": [
-                {
-                  "id": "https://example.org/iiif/3d/cameras/1",
-                  "type": "PerspectiveCamera",
-                  "label": {"en": ["Perspective Camera Pointed At Pterygoid Hamulus"]},
-                  "fieldOfView": 50.0,
-                  "near": 0.10,
-                  "far": 2000.0
-                }
-              ],
-              "transform": [
-                {
-                  "type": "RotateTransform",
-                  "x": -15.0,
-                  "y": 215.0,
-                  "z": 0.0
-                }
-              ]
-            },
-            "target": {
-              "type": "SpecificResource",
-              "source": [
-                {
-                  "id": "https://example.org/iiif/scene1",
-                  "type": "Scene"
-                }
-              ],
-              "selector": [
-                {
-                  "type": "PointSelector",
-                  "x": -0.25,
-                  "y": 0.0,
-                  "z": -0.5
-                }
-              ]
+      "id": "https://example.org/iiif/scene1/page/p1/annotations/1",
+      "type": "AnnotationPage",
+      "items": [
+        {
+          "id": "https://example.org/iiif/3d/anno7",
+          "type": "Annotation",
+          "motivation": ["commenting"],
+          "bodyValue": "Mandibular tooth",
+          "target": {
+            "type": "SpecificResource",
+            "source": [
+              {
+                "id": "https://example.org/iiif/scene1",
+                "type": "Scene"
+              }
+            ],
+            "selector": [
+              {
+                "type": "PointSelector",
+                "x": 0.011,
+                "y": 0.069,
+                "z": 0.231
+              }
+            ],
+            "scope": {
+              "@context": "http://iiif.io/api/presentation/4/context.json",
+              "id": "https://example.org/iiif/3d/anno4",
+              "type": "Annotation",
+              "motivation": ["contentState"],
+              "target": {
+                "id": "https://example.org/iiif/scene1/page/p1/1",
+                "type": "Scene",
+                "backgroundColor": "yellow",
+                "items": [
+                  {
+                    "id": "https://example.org/iiif/3d/anno8",
+                    "type": "Annotation",
+                    "motivation": ["painting"],
+                    "body": {
+                      "type": "SpecificResource",
+                      "source": [
+                        {
+                          "id": "https://example.org/iiif/3d/cameras/1",
+                          "type": "PerspectiveCamera",
+                          "label": {"en": ["Perspective Camera Pointed At Front of Cranium and Mandible"]},
+                          "fieldOfView": 50.0,
+                          "near": 0.10,
+                          "far": 2000.0
+                        }
+                      ]
+                    },
+                    "target": {
+                      "type": "SpecificResource",
+                      "source": [
+                        {
+                          "id": "https://example.org/iiif/scene1",
+                          "type": "Scene"
+                        }
+                      ],
+                      "selector": [
+                        {
+                          "type": "PointSelector",
+                          "x": 0.0,
+                          "y": 0.15,
+                          "z": 0.75
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
             }
           }
-        ]
-      }
-    },
-    {
-      "@context": "http://iiif.io/api/presentation/4/context.json",
-      "id": "https://example.org/iiif/3d/anno4",
-      "type": "Annotation",
-      "motivation": ["contentState"],
-      "target": {
-        "id": "https://example.org/iiif/scene1/page/p1/1",
-        "type": "Scene",
-        "backgroundColor": "yellow",
-        "items": [
-          {
-            "id": "https://example.org/iiif/3d/anno7",
-            "type": "Annotation",
-            "motivation": ["commenting"],
-            "bodyValue": "Mandibular tooth",
-            "target": {
-              "type": "SpecificResource",
-              "source": [
-                {
-                  "id": "https://example.org/iiif/scene1",
-                  "type": "Scene"
-                }
-              ],
-              "selector": [
-                {
-                  "type": "PointSelector",
-                  "x": 0.011,
-                  "y": 0.069,
-                  "z": 0.231
-                }
-              ]
-            }
-          },
-          {
-            "id": "https://example.org/iiif/3d/anno8",
-            "type": "Annotation",
-            "motivation": ["painting"],
-            "body": {
-              "type": "SpecificResource",
-              "source": [
-                {
-                  "id": "https://example.org/iiif/3d/cameras/1",
-                  "type": "PerspectiveCamera",
-                  "label": {"en": ["Perspective Camera Pointed At Front of Cranium and Mandible"]},
-                  "fieldOfView": 50.0,
-                  "near": 0.10,
-                  "far": 2000.0
-                }
-              ]
-            },
-            "target": {
-              "type": "SpecificResource",
-              "source": [
-                {
-                  "id": "https://example.org/iiif/scene1",
-                  "type": "Scene"
-                }
-              ],
-              "selector": [
-                {
-                  "type": "PointSelector",
-                  "x": 0.0,
-                  "y": 0.15,
-                  "z": 0.75
-                }
-              ]
+        },
+        {
+          "id": "https://example.org/iiif/3d/anno5",
+          "type": "Annotation",
+          "motivation": ["commenting"],
+          "bodyValue": "Right pterygoid hamulus",
+          "target": {
+            "type": "SpecificResource",
+            "source": [
+              {
+                "id": "https://example.org/iiif/scene1",
+                "type": "Scene"
+              }
+            ],
+            "selector": [
+              {
+                "type": "PointSelector",
+                "x": 0.040,
+                "y": 0.063,
+                "z": -0.066
+              }
+            ],
+            "scope":  {
+              "@context": "http://iiif.io/api/presentation/4/context.json",
+              "id": "https://example.org/iiif/3d/anno3",
+              "type": "Annotation",
+              "motivation": ["contentState"],
+              "target": {
+                "id": "https://example.org/iiif/scene1/page/p1/1",
+                "type": "Scene",
+                "backgroundColor": "green",
+                "items": [
+                  {
+                    "id": "https://example.org/iiif/3d/anno6",
+                    "type": "Annotation",
+                    "motivation": ["painting"],
+                    "body": {
+                      "type": "SpecificResource",
+                      "source": [
+                        {
+                          "id": "https://example.org/iiif/3d/cameras/1",
+                          "type": "PerspectiveCamera",
+                          "label": {"en": ["Perspective Camera Pointed At Pterygoid Hamulus"]},
+                          "fieldOfView": 50.0,
+                          "near": 0.10,
+                          "far": 2000.0
+                        }
+                      ],
+                      "transform": [
+                        {
+                          "type": "RotateTransform",
+                          "x": -15.0,
+                          "y": 215.0,
+                          "z": 0.0
+                        }
+                      ]
+                    },
+                    "target": {
+                      "type": "SpecificResource",
+                      "source": [
+                        {
+                          "id": "https://example.org/iiif/scene1",
+                          "type": "Scene"
+                        }
+                      ],
+                      "selector": [
+                        {
+                          "type": "PointSelector",
+                          "x": -0.25,
+                          "y": 0.0,
+                          "z": -0.5
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
             }
           }
-        ]
-      }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Changes:
* Move `commenting` annos to `annotations`
* Move `scope` to property of `target` for each `commenting` annotation
