### PR TITLE
Add format to model painting annotations, in some cases correct format mime type

### DIFF
--- a/manifests/10_content_state/whale_comment_scope_content_state.json
+++ b/manifests/10_content_state/whale_comment_scope_content_state.json
@@ -20,7 +20,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/whale/whale_mandible.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": {
                 "type": "SpecificResource",
@@ -46,7 +47,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/whale/whale_cranium.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": {
                 "type": "SpecificResource",

--- a/manifests/1_basic_model_in_scene/model_origin.json
+++ b/manifests/1_basic_model_in_scene/model_origin.json
@@ -20,7 +20,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": "https://example.org/iiif/scene1/page/p1/1"
             }

--- a/manifests/1_basic_model_in_scene/model_origin_bgcolor.json
+++ b/manifests/1_basic_model_in_scene/model_origin_bgcolor.json
@@ -21,7 +21,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": "https://example.org/iiif/scene1/page/p1/1"
             }

--- a/manifests/2_cameras/perspective_camera.json
+++ b/manifests/2_cameras/perspective_camera.json
@@ -20,7 +20,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": "https://example.org/iiif/scene1/page/p1/1"
             },

--- a/manifests/2_cameras/positioned_camera_lookat_anno.json
+++ b/manifests/2_cameras/positioned_camera_lookat_anno.json
@@ -21,7 +21,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": "https://example.org/iiif/scene1/page/p1/1"
             },

--- a/manifests/2_cameras/positioned_camera_lookat_point.json
+++ b/manifests/2_cameras/positioned_camera_lookat_point.json
@@ -21,7 +21,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": "https://example.org/iiif/scene1/page/p1/1"
             },

--- a/manifests/2_cameras/zz_choice_of_cameras.json
+++ b/manifests/2_cameras/zz_choice_of_cameras.json
@@ -23,7 +23,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": "https://example.org/iiif/scene1/page/p1/1"
             },

--- a/manifests/2_cameras/zz_orthographic_camera.json
+++ b/manifests/2_cameras/zz_orthographic_camera.json
@@ -19,7 +19,8 @@
                 "motivation": ["painting"],
                 "body": {
                   "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
-                  "type": "Model"
+                  "type": "Model",
+                "format": "model/gltf-binary"
                 },
                 "target": "https://example.org/iiif/scene1/page/p1/1"
               },

--- a/manifests/3_lights/ambient_green_light.json
+++ b/manifests/3_lights/ambient_green_light.json
@@ -20,7 +20,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": "https://example.org/iiif/scene1/page/p1/1"
             },

--- a/manifests/3_lights/direction_light_lookat_positioned.json
+++ b/manifests/3_lights/direction_light_lookat_positioned.json
@@ -21,7 +21,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": "https://example.org/iiif/scene1/page/p1/1"
             },

--- a/manifests/3_lights/direction_light_transform_rotate.json
+++ b/manifests/3_lights/direction_light_transform_rotate.json
@@ -21,7 +21,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": "https://example.org/iiif/scene1/page/p1/1"
             },

--- a/manifests/4_transform_and_position/model_position.json
+++ b/manifests/4_transform_and_position/model_position.json
@@ -20,7 +20,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": {
                 "type": "SpecificResource",

--- a/manifests/4_transform_and_position/model_transform_negative_scale_position.json
+++ b/manifests/4_transform_and_position/model_transform_negative_scale_position.json
@@ -20,7 +20,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": {
                 "type": "SpecificResource",
@@ -50,7 +51,7 @@
                   {
                     "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
                     "type": "Model",
-                    "format": "application/glb"
+                    "format": "model/gltf-binary"
                   }
                 ],
                 "transform": [

--- a/manifests/4_transform_and_position/model_transform_rotate_position.json
+++ b/manifests/4_transform_and_position/model_transform_rotate_position.json
@@ -24,7 +24,7 @@
                   {
                     "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
                     "type": "Model",
-                    "format": "application/glb"
+                    "format": "model/gltf-binary"
                   }
                 ],
                 "transform": [

--- a/manifests/4_transform_and_position/model_transform_rotate_translate_position.json
+++ b/manifests/4_transform_and_position/model_transform_rotate_translate_position.json
@@ -24,7 +24,7 @@
                   {
                     "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
                     "type": "Model",
-                    "format": "application/glb"
+                    "format": "model/gltf-binary"
                   }
                 ],
                 "transform": [

--- a/manifests/4_transform_and_position/model_transform_scale_position.json
+++ b/manifests/4_transform_and_position/model_transform_scale_position.json
@@ -20,7 +20,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": {
                 "type": "SpecificResource",
@@ -50,7 +51,7 @@
                   {
                     "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
                     "type": "Model",
-                    "format": "application/glb"
+                    "format": "model/gltf-binary"
                   }
                 ],
                 "transform": [

--- a/manifests/4_transform_and_position/model_transform_scale_translate_position.json
+++ b/manifests/4_transform_and_position/model_transform_scale_translate_position.json
@@ -20,7 +20,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": {
                 "type": "SpecificResource",
@@ -50,7 +51,7 @@
                   {
                     "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
                     "type": "Model",
-                    "format": "application/glb"
+                    "format": "model/gltf-binary"
                   }
                 ],
                 "transform": [

--- a/manifests/4_transform_and_position/model_transform_translate_rotate_position.json
+++ b/manifests/4_transform_and_position/model_transform_translate_rotate_position.json
@@ -24,7 +24,7 @@
                   {
                     "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
                     "type": "Model",
-                    "format": "application/glb"
+                    "format": "model/gltf-binary"
                   }
                 ],
                 "transform": [

--- a/manifests/4_transform_and_position/model_transform_translate_scale_position.json
+++ b/manifests/4_transform_and_position/model_transform_translate_scale_position.json
@@ -20,7 +20,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": {
                 "type": "SpecificResource",
@@ -50,7 +51,7 @@
                   {
                     "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
                     "type": "Model",
-                    "format": "application/glb"
+                    "format": "model/gltf-binary"
                   }
                 ],
                 "transform": [

--- a/manifests/4_transform_and_position/whale_cranium_and_mandible_position.json
+++ b/manifests/4_transform_and_position/whale_cranium_and_mandible_position.json
@@ -20,7 +20,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/whale/whale_mandible.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": {
                 "type": "SpecificResource",
@@ -46,7 +47,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/whale/whale_cranium.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": {
                 "type": "SpecificResource",

--- a/manifests/6_2d_canvases_in_scene/iiif_canvas_with_bgcolor_backward.json
+++ b/manifests/6_2d_canvases_in_scene/iiif_canvas_with_bgcolor_backward.json
@@ -33,7 +33,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": "https://example.org/iiif/scene1/page/p1/1"
             },

--- a/manifests/6_2d_canvases_in_scene/iiif_canvas_with_bgcolor_forward.json
+++ b/manifests/6_2d_canvases_in_scene/iiif_canvas_with_bgcolor_forward.json
@@ -33,7 +33,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/astronaut/astronaut.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": "https://example.org/iiif/scene1/page/p1/1"
             },

--- a/manifests/9_commenting_annotations/whale_comment.json
+++ b/manifests/9_commenting_annotations/whale_comment.json
@@ -20,7 +20,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/whale/whale_mandible.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": {
                 "type": "SpecificResource",
@@ -46,7 +47,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/whale/whale_cranium.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": {
                 "type": "SpecificResource",

--- a/manifests/9_commenting_annotations/whale_comment_camera.json
+++ b/manifests/9_commenting_annotations/whale_comment_camera.json
@@ -20,7 +20,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/whale/whale_mandible.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": {
                 "type": "SpecificResource",
@@ -46,7 +47,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/whale/whale_cranium.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": {
                 "type": "SpecificResource",

--- a/manifests/9_commenting_annotations/whale_comment_label_body_position.json
+++ b/manifests/9_commenting_annotations/whale_comment_label_body_position.json
@@ -20,7 +20,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/whale/whale_mandible.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": {
                 "type": "SpecificResource",
@@ -46,7 +47,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/whale/whale_cranium.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": {
                 "type": "SpecificResource",

--- a/manifests/9_commenting_annotations/whale_comment_label_body_position_rotate.json
+++ b/manifests/9_commenting_annotations/whale_comment_label_body_position_rotate.json
@@ -20,7 +20,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/whale/whale_mandible.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": {
                 "type": "SpecificResource",
@@ -46,7 +47,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/whale/whale_cranium.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": {
                 "type": "SpecificResource",

--- a/manifests/9_commenting_annotations/whale_comment_point_polygon.json
+++ b/manifests/9_commenting_annotations/whale_comment_point_polygon.json
@@ -20,7 +20,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/whale/whale_mandible.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": {
                 "type": "SpecificResource",
@@ -46,7 +47,8 @@
               "motivation": ["painting"],
               "body": {
                 "id": "https://raw.githubusercontent.com/IIIF/3d/main/assets/whale/whale_cranium.glb",
-                "type": "Model"
+                "type": "Model",
+                "format": "model/gltf-binary"
               },
               "target": {
                 "type": "SpecificResource",


### PR DESCRIPTION
Some viewers (like UV) depend on mime type format in order to decide which extension to use to view content, so this PR adds format to all painting model annotations. Format was already present with an incorrect mime type for a few annotations, so those are corrected.