### PR TITLE
Added entry for X3DOM based manifest viewer

### DIFF
--- a/_data/viewers.yml
+++ b/_data/viewers.yml
@@ -4,3 +4,5 @@
   url: https://smithsonian.github.io/dpo-voyager/docs/iiif_demo?document=##manifest##
 - name: Universal Viewer
   url: https://uv-v4.netlify.app/#?manifest=##manifest##
+- name: X3DOM Viewer
+  url: https://spri-open-resources.s3.us-east-2.amazonaws.com/iiif3dtsg/manifest/index.html#?manifest=##manifest##


### PR DESCRIPTION
Have added a line for the X3DOM-based manifest viewer, displaying  manifest as referenced by a url passed in fragment section of url

This is an example URL which works: 
https://spri-open-resources.s3.us-east-2.amazonaws.com/iiif3dtsg/manifest/index.html#?manifest=https://iiif.github.io/3d/manifests/1_basic_model_in_scene/model_origin.json
