### PR TITLE
Add Kompakkt Viewer to viewers.yml

### DIFF
--- a/_data/viewers.yml
+++ b/_data/viewers.yml
@@ -6,3 +6,5 @@
   url: https://uv-v4.netlify.app/#?manifest=##manifest##
 - name: X3DOM Viewer
   url: https://spri-open-resources.s3.us-east-2.amazonaws.com/iiif3dtsg/manifest/index.html#?manifest=##manifest##
+- name: Kompakkt Viewer
+  url: https://blacklodge.hki.uni-koeln.de/viewer/?locale=en&standalone=true&manifest=##manifest##


### PR DESCRIPTION
This is using the current IIIF 3d demo branch of the Kompakkt viewer, where manifests can be loaded via URL search parameter.