### PR TITLE
Update manifests to conform to stricter requirements of Presentation 4 Properties

### DIFF
--- a/manifests/1_basic_model_in_scene/model_origin.json
+++ b/manifests/1_basic_model_in_scene/model_origin.json
@@ -23,7 +23,10 @@
                 "type": "Model",
                 "format": "model/gltf-binary"
               },
-              "target": "https://example.org/iiif/scene1/page/p1/1"
+              "target": {
+                "id"   : "https://example.org/iiif/scene1/page/p1/1",
+                "type" : "Scene"
+              }
             }
           ]
         }

--- a/manifests/1_basic_model_in_scene/model_origin_bgcolor.json
+++ b/manifests/1_basic_model_in_scene/model_origin_bgcolor.json
@@ -24,7 +24,10 @@
                 "type": "Model",
                 "format": "model/gltf-binary"
               },
-              "target": "https://example.org/iiif/scene1/page/p1/1"
+              "target": {
+                "id"   : "https://example.org/iiif/scene1/page/p1/1",
+                "type" : "Scene"
+              } 
             }
           ]
         }


### PR DESCRIPTION
Each of these manifests had a target property that was a string 
 interpreted as the id of a Scene resource

Section 4.2 of the Presentation 4.0 Properties document https://preview.iiif.io/api/prezi-4/presentation/4.0/properties/#42-resource-representations no longer allow this.

The target property has been set to the JSON representation of an object with type and id properties