### PR TITLE
Bring 2_cameras manifests into conformance with presentation-validator

### DIFF
--- a/manifests/2_cameras/perspective_camera.json
+++ b/manifests/2_cameras/perspective_camera.json
@@ -23,7 +23,10 @@
                 "type": "Model",
                 "format": "model/gltf-binary"
               },
-              "target": "https://example.org/iiif/scene1"
+              "target": {
+                "id" : "https://example.org/iiif/scene1",
+                "type" : "Scene"
+              }
             },
             {
               "id": "https://example.org/iiif/3d/anno2",
@@ -34,7 +37,10 @@
                 "type": "PerspectiveCamera",
                 "label": {"en": ["Perspective Camera 1"]}
               },
-              "target": "https://example.org/iiif/scene1"
+              "target": {
+                "id" : "https://example.org/iiif/scene1",
+                "type" : "Scene"
+              }
             }
           ]
         }

--- a/manifests/2_cameras/positioned_camera_lookat_anno.json
+++ b/manifests/2_cameras/positioned_camera_lookat_anno.json
@@ -24,7 +24,10 @@
                 "type": "Model",
                 "format": "model/gltf-binary"
               },
-              "target": "https://example.org/iiif/scene1"
+              "target": {
+                "id" : "https://example.org/iiif/scene1",
+                "type" : "Scene"
+              }
             },
             {
               "id": "https://example.org/iiif/3d/anno2",
@@ -40,21 +43,18 @@
                 }
               },
               "target": {
+                "id"  : "https://example.org/iiif/specificresource/1",
                 "type": "SpecificResource",
-                "source": [
-                  {
+                "source": {
                     "id": "https://example.org/iiif/scene1",
                     "type": "Scene"
-                  }
-                ],
-                "selector": [
-                  {
+                  },
+                "selector":  {
                     "type": "PointSelector",
                     "x": 0.0,
                     "y": 3.0,
                     "z": -10.0
-                  }
-                ]
+                }
               }
             }
           ]

--- a/manifests/2_cameras/positioned_camera_lookat_point.json
+++ b/manifests/2_cameras/positioned_camera_lookat_point.json
@@ -24,7 +24,10 @@
                 "type": "Model",
                 "format": "model/gltf-binary"
               },
-              "target": "https://example.org/iiif/scene1"
+              "target": {
+                "id" : "https://example.org/iiif/scene1",
+                "type" : "Scene"
+              }
             },
             {
               "id": "https://example.org/iiif/3d/anno2",
@@ -42,21 +45,22 @@
                 }
               },
               "target": {
+                "id"  : "https://example.org/iiif/specificresource/1",
                 "type": "SpecificResource",
-                "source": [
+                "source": 
                   {
                     "id": "https://example.org/iiif/scene1",
                     "type": "Scene"
                   }
-                ],
-                "selector": [
+                ,
+                "selector": 
                   {
                     "type": "PointSelector",
                     "x": 0.0,
                     "y": 3.0,
                     "z": -10.0
                   }
-                ]
+                
               }
             }
           ]

--- a/manifests/2_cameras/zz_choice_of_cameras.json
+++ b/manifests/2_cameras/zz_choice_of_cameras.json
@@ -10,7 +10,7 @@
   },
   "items": [
     {
-      "id": "https://example.org/iiif/scene1/page/p1/1",
+      "id": "https://example.org/iiif/scene1/1",
       "type": "Scene",
       "items": [
         {
@@ -26,18 +26,32 @@
                 "type": "Model",
                 "format": "model/gltf-binary"
               },
-              "target": "https://example.org/iiif/scene1/page/p1/1"
+              "target": {
+                "id" : "https://example.org/iiif/scene1/1",
+                "type" : "Scene"
+              }
             },
 
             {
-              "id": "https://example.org/iiif/3d/choice",
-              "type": "Choice",
-              "items": [
-                {
-                  "id": "https://example.org/iiif/3d/anno2",
-                  "type": "Annotation",
-                  "motivation": ["painting"],
-                  "body": {
+              "id": "https://example.org/iiif/3d/anno2",
+              "type": "Annotation",
+              "motivation": ["painting"],
+              "body": {
+                "id": "https://example.org/iiif/3d/choice",
+                "type": "Choice",
+                "items": [
+                  {
+                    "id": "https://example.org/iiif/3d/cameras/2",
+                    "type": "OrthographicCamera",
+                    "label": { "en": ["Orthographic Camera 1"] },
+                    "lookAt": {
+                      "type": "PointSelector",
+                      "x": 2,
+                      "y": 1,
+                      "z": 0
+                      }
+                  },
+                  {
                     "id": "https://example.org/iiif/3d/cameras/1",
                     "type": "PerspectiveCamera",
                     "fieldOfView": 50,
@@ -48,61 +62,25 @@
                       "y": 1,
                       "z": 0
                     }
-                  },
-                  "target": {
-                    "type": "SpecificResource",
-                    "source": [
-                      {
-                        "id": "https://example.org/iiif/scene1/page/p1/1",
-                        "type": "Scene"
-                      }
-                    ],
-                    "selector": [
-                      {
-                        "type": "PointSelector",
-                        "x": 0.0,
-                        "y": 3.0,
-                        "z": -10.0
-                      }
-                    ]
                   }
-                },
-                {
-                  "id": "https://example.org/iiif/3d/anno3",
-                  "type": "Annotation",
-                  "motivation": ["painting"],
-                  "body": {
-                    "id": "https://example.org/iiif/3d/cameras/2",
-                    "type": "OrthographicCamera",
-                    "label": { "en": ["Orthographic Camera 1"] },
-                    "lookAt": {
-                      "type": "PointSelector",
-                      "x": 2,
-                      "y": 1,
-                      "z": 0
-                    }
+                ]
+              },
+              "target": {
+                "id": "https://example.org/iiif/specificresource/1",
+                "type": "SpecificResource",
+                "source": {
+                    "id": "https://example.org/iiif/scene1/1",
+                    "type": "Scene"
                   },
-                  "target": {
-                    "type": "SpecificResource",
-                    "source": [
-                      {
-                        "id": "https://example.org/iiif/scene1/page/p1/1",
-                        "type": "Scene"
-                      }
-                    ],
-                    "selector": [
-                      {
-                        "type": "PointSelector",
-                        "x": 0.0,
-                        "y": 3.0,
-                        "z": -10.0
-                      }
-                    ]
+                "selector": {
+                    "type": "PointSelector",
+                    "x": 0.0,
+                    "y": 3.0,
+                    "z": -10.0
                   }
-                }
-              ]
+              }
             }
-          ]
+           ]
         }
       ]
     }

--- a/manifests/2_cameras/zz_orthographic_camera.json
+++ b/manifests/2_cameras/zz_orthographic_camera.json
@@ -6,7 +6,7 @@
     "summary": { "en": ["Viewer should render the model at the scene origin and an Orthographic camera looking at the model, and add default lighting."] },
     "items": [
       {
-        "id": "https://example.org/iiif/scene1/page/p1/1",
+        "id": "https://example.org/iiif/scene1/scene/1",
         "type": "Scene",
         "items": [
           {
@@ -22,7 +22,10 @@
                   "type": "Model",
                 "format": "model/gltf-binary"
                 },
-                "target": "https://example.org/iiif/scene1/page/p1/1"
+                "target": {
+                    "id" : "https://example.org/iiif/scene1/scene/1",
+                    "type" : "Scene"
+                }
               },
               {
                 "id": "https://example.org/iiif/3d/anno3",
@@ -38,21 +41,18 @@
                   }
                 },
                 "target": {
+                  "id"  : "https://example.org/iiif/specificresource/1",
                   "type": "SpecificResource",
-                  "source": [
-                    {
-                      "id": "https://example.org/iiif/scene1/page/p1/1",
+                  "source":  {
+                      "id": "https://example.org/iiif/scene1/scene/1",
                       "type": "Scene"
-                    }
-                  ],
-                  "selector": [
-                    {
+                  },
+                  "selector":{
                       "type": "PointSelector",
                       "x": 0.0,
                       "y": 3.0,
                       "z": -10.0
-                    }
-                  ]
+                  }
                 }
               }
             ]


### PR DESCRIPTION
Manifest files were edited to eliminate errors identified by the presentation-validator

Validation errors that have been fixed were primarily replacing Annotation target  values tha were strings with values that were JSON objects; for these manifests the targets were Scene resources.

Adding https schema ids to resources that didnt' have them, primarily SpecificResource objects