### PR TITLE
Canvas in scene manifest updates to match draft spec

### DIFF
--- a/manifests/6_2d_canvases_in_scene/iiif_canvas_with_bgcolor_backward.json
+++ b/manifests/6_2d_canvases_in_scene/iiif_canvas_with_bgcolor_backward.json
@@ -46,8 +46,26 @@
               "type": "Annotation",
               "motivation": ["painting"],
               "body": {
-                "id": "https://example.org/iiif/canvas/1",
-                "type": "Canvas"
+                "id": "https://iiif.io/api/presentation/4.0/example/uc06/scene/canvas-scene/anno/2/specificResource/1",
+                "type": "SpecificResource",
+                "source": {
+                  "id": "https://example.org/iiif/canvas/1",
+                  "type": "Canvas"
+                },
+                "transform": [
+                  {
+                    "type": "ScaleTransform",
+                    "x": 2.1687,
+                    "y": 2.8273,
+                    "z": 1.0
+                  },
+                  {
+                    "type": "RotateTransform",
+                    "x": 0.0,
+                    "y": 180.0,
+                    "z": 0.0
+                  }
+                ]
               },
               "target": {
                 "id": "https://example.org/iiif/3d/anno2/target",
@@ -58,8 +76,10 @@
                 },
                 "selector": [
                   {
-                    "type": "PolygonZSelector",
-                    "value": "POLYGONZ((-1.0843 2.8273 -2, 1.0843 2.8273 -2, 1.0843 0 -2, -1.0843 0 -2))"
+                    "type": "PointSelector",
+                    "x": 1.08435,
+                    "y": 2.8273,
+                    "z": -2.0
                   }
                 ]
               }
@@ -73,8 +93,8 @@
       "type": "Canvas",
       "label": { "en": ["Painting"]},
       "backgroundColor": "#c0c0c0",
-      "height": 28273,
-      "width": 21687,
+      "height": 1,
+      "width": 1,
       "items": [
         {
           "id": "https://example.org/iiif/scene1/page/p2/1",

--- a/manifests/6_2d_canvases_in_scene/iiif_canvas_with_bgcolor_forward.json
+++ b/manifests/6_2d_canvases_in_scene/iiif_canvas_with_bgcolor_forward.json
@@ -88,7 +88,7 @@
       "label": { "en": ["Painting"]},
       "backgroundColor": "#c0c0c0",
       "width": 1,
-	    "height": 1,
+	  "height": 1,
       "items": [
         {
           "id": "https://example.org/iiif/scene1/page/p2/1",

--- a/manifests/6_2d_canvases_in_scene/iiif_canvas_with_bgcolor_forward.json
+++ b/manifests/6_2d_canvases_in_scene/iiif_canvas_with_bgcolor_forward.json
@@ -46,8 +46,20 @@
               "type": "Annotation",
               "motivation": ["painting"],
               "body": {
-                "id": "https://example.org/iiif/canvas/1",
-                "type": "Canvas"
+                "id": "https://iiif.io/api/presentation/4.0/example/uc06/scene/canvas-scene/anno/2/specificResource/1",
+                "type": "SpecificResource",
+                "source": {
+                  "id": "https://example.org/iiif/canvas/1",
+                  "type": "Canvas"
+                },
+                "transform": [
+                  {
+                    "type": "ScaleTransform",
+                    "x": 2.1687,
+                    "y": 2.8273,
+                    "z": 1.0
+                  }
+                ]
               },
               "target": {
                 "id": "https://example.org/iiif/3d/anno2/target",
@@ -58,8 +70,10 @@
                 },
                 "selector": [
                   {
-                    "type": "PolygonZSelector",
-                    "value": "POLYGONZ((-1.0843 2.8273 -2, -1.0843 0 -2, 1.0843 0 -2, 1.0843 2.8273 -2))"
+                    "type": "PointSelector",
+                    "x": -1.08435,
+                    "y": 2.8273,
+                    "z": -2.0
                   }
                 ]
               }
@@ -73,8 +87,8 @@
       "type": "Canvas",
       "label": { "en": ["Painting"]},
       "backgroundColor": "#c0c0c0",
-      "height": 28273,
-      "width": 21687,
+      "width": 1,
+	    "height": 1,
       "items": [
         {
           "id": "https://example.org/iiif/scene1/page/p2/1",


### PR DESCRIPTION
Updates to canvas in scene manifests. With my dev Voyager branch the result is the same as with the previous versions, but makes an assumption I'm unsure about outlined below.

- Set canvas height and width to '1' to more easily replicate the physical size from the old manifest using a scale transform.
- Changed PolygonZ selector to PointSelector
- Changed annotation body to a specific reference so that a transforms could be added for scale (and rotation in the case of the 'backwards' example). It's not clear to me if this is the correct way to do this, happy to update if not.